### PR TITLE
fix: convert boundary_ratio from timestep space to index space

### DIFF
--- a/mova/diffusion/pipelines/mova_train.py
+++ b/mova/diffusion/pipelines/mova_train.py
@@ -1386,14 +1386,9 @@ class MOVATrain(BasePipeline, DiffusionPipeline):
             mode_scale=1.0,
             independent_timesteps=False,
         )
-        # The sigma_shift formula in flow_match.py L57:
-        #   sigma_shifted = shift * sigma_linear / (1 + (shift - 1) * sigma_linear)
-        # boundary_ratio is in shifted space; invert to get sigma_linear:
-        #   sigma_linear = boundary_ratio / (shift - (shift - 1) * boundary_ratio)
-        # index_boundary = 1 - sigma_linear, which simplifies to:
-        #   shift * (1 - boundary_ratio) / (1 + (shift - 1) * (1 - boundary_ratio))
-        # e.g. shift=3, boundary_ratio=0.9 => sigma_linear=0.75 => index=0.25
-        boundary = self.scheduler.shift * (1 - self.boundary_ratio) / (1 + (self.scheduler.shift - 1) * (1 - self.boundary_ratio))
+        # Look up the index boundary directly from the scheduler's timestep table.
+        # boundary_ratio=0.9 means timestep 900; count how many timesteps >= 900 to get the index fraction.
+        boundary = (self.scheduler.timesteps >= self.boundary_ratio * self.scheduler.num_train_timesteps).sum().item() / self.scheduler.num_train_timesteps
         if global_step % 2 == 0:
             timestep_config.max_timestep_boundary = boundary
         else:


### PR DESCRIPTION
## Summary

`boundary_ratio=0.9` represents the DiT1/DiT2 switch point at timestep 900. In inference, this value is correctly compared against actual timestep values. However, in `training_step`, it was incorrectly used as an index fraction for `max/min_timestep_boundary`.

Due to sigma_shift (flow_match.py L57), the scheduler's timestep array is non-linearly spaced — timestep 900 sits at index ~250 (shift=3), not index 900. Using 0.9 as the index boundary caused DiT1 to be trained on 90% of indices and DiT2 on only 10%, while in inference DiT2 handles the majority of denoising (timestep 900→0).

## Fix

Apply inverse sigma_shift to convert `boundary_ratio` from timestep space to index space before passing it to `max/min_timestep_boundary`. This aligns training with inference behavior.

- shift=3 → index boundary = 0.25
- shift=5 → index boundary = 0.358 (matches DiffSynth-Studio PR #806)

## Reference

- https://github.com/modelscope/DiffSynth-Studio/pull/806