### PR TITLE
fix: CPU OOM issue during LoRA training

### DIFF
--- a/mova/engine/trainer/accelerate/accelerate_trainer.py
+++ b/mova/engine/trainer/accelerate/accelerate_trainer.py
@@ -276,7 +276,7 @@ class AccelerateTrainer:
         if self.is_main_process:
             os.makedirs(self.save_path, exist_ok=True)
         
-        torch.cuda.memory._record_memory_history(enabled='all')
+        # torch.cuda.memory._record_memory_history(enabled='all')
     
     def _setup_lora(self):
         """Configure LoRA"""


### PR DESCRIPTION
When conducting fine-tuning with the provided LoRA training script, CPU memory usage continuously increases over time and eventually the process is killed by the system due to out-of-memory (OOM).

The issue is caused by enabling `torch.cuda.memory._record_memory_history(enabled="all")`, which records CUDA memory events and stores them on the CPU. As training progresses, the accumulated memory history leads to excessive CPU memory consumption, resulting in CPU OOM.