### PR TITLE
feat(workflow): add MiniMax as alternative LLM provider for prompt generation

### DIFF
--- a/workflow/README.md
+++ b/workflow/README.md
@@ -43,8 +43,9 @@ Edit `config.py` to set:
 - **API Keys** (optional, for Full Workflow):
   - `GEMINI_API_KEY` + `GEMINI_API_URL`: Gemini API (recommended; fill base URL when using proxy)
   - `DASHSCOPE_API_KEY` + `DASHSCOPE_BASE_URL`: Qwen/DashScope API (base URL for region, e.g. Singapore/US)
+  - `MINIMAX_API_KEY`: [MiniMax](https://platform.minimaxi.com/) API for prompt generation (OpenAI-compatible; uses MiniMax-M2.7 by default)
 
-> **Note (API Key Fallback):** If you do **not** provide a Gemini API key, the workflow will automatically use the Qwen (DashScope) API key to call qwen-plus and Z-Image for prompt generation and first frame generation. **We still recommend using a Gemini API key** for better quality.
+> **Note (API Key Fallback):** If you do **not** provide a Gemini API key, the workflow will automatically use the Qwen (DashScope) API key to call qwen-plus and Z-Image for prompt generation and first frame generation. Alternatively, you can use a **MiniMax API key** (`MINIMAX_API_KEY`) for prompt rewriting and image prompt generation via MiniMax's OpenAI-compatible API. **We still recommend using a Gemini API key** for best quality.
 
 #### Step 3: Start Streamlit App
 
@@ -67,9 +68,9 @@ Open the URL shown in the terminal (e.g., http://localhost:8500) and use the web
 | `api_utils.py` | Shared API helpers (DashScope URL setup, API key resolution) |
 | `config.py` | Server URLs, API keys, default parameters |
 | `sglang_client.py` | SGLang video API client |
-| `generate_first_frame.py` | Image prompt + first frame generation (Gemini or qwen-plus + Z-Image) |
+| `generate_first_frame.py` | Image prompt + first frame generation (Gemini, qwen-plus, or MiniMax + Z-Image) |
 | `qwen_vl_api.py` | Visual element extraction from image (Qwen3-VL) |
-| `prompt_rewriter_with_image.py` | Video description rewriting (Gemini or qwen-plus) |
+| `prompt_rewriter_with_image.py` | Video description rewriting (Gemini, qwen-plus, or MiniMax) |
 | `launch_sglang_server.sh` | SGLang server launcher (set `MOVA_MODEL_PATH` to your checkpoint dir) |
 | `launch_streamlit.sh` | Streamlit app launcher |
 
@@ -114,8 +115,9 @@ export MOVA_MODEL_PATH="/path/to/your/MOVA-360p-hf"   # 或 MOVA-720p-hf
 - **API 密钥**（可选，完整工作流需要）：
   - `GEMINI_API_KEY` + `GEMINI_API_URL`：Gemini API（推荐；使用代理时需填写 base URL）
   - `DASHSCOPE_API_KEY` + `DASHSCOPE_BASE_URL`：通义千问 / DashScope API（base URL 可选，用于指定地域如新加坡/美国）
+  - `MINIMAX_API_KEY`：[MiniMax](https://platform.minimaxi.com/) API，用于提示词生成（OpenAI 兼容接口；默认使用 MiniMax-M2.7）
 
-> **说明（API 密钥回退）：** 若不提供 Gemini API 密钥，工作流会自动使用 Qwen（DashScope）API 密钥调用 qwen-plus 和 Z-Image 完成提示词生成和首帧图生成。**我们仍推荐使用 Gemini API 密钥**以获得更好效果。
+> **说明（API 密钥回退）：** 若不提供 Gemini API 密钥，工作流会自动使用 Qwen（DashScope）API 密钥调用 qwen-plus 和 Z-Image 完成提示词生成和首帧图生成。也可使用 **MiniMax API 密钥**（`MINIMAX_API_KEY`）通过 MiniMax 的 OpenAI 兼容 API 完成提示词改写和首帧图提示词生成。**我们仍推荐使用 Gemini API 密钥**以获得更好效果。
 
 #### 第三步：启动 Streamlit 应用
 
@@ -138,8 +140,8 @@ export MOVA_MODEL_PATH="/path/to/your/MOVA-360p-hf"   # 或 MOVA-720p-hf
 | `api_utils.py` | API 工具（DashScope URL 设置、API Key 解析等） |
 | `config.py` | 服务 URL、API 密钥、默认参数 |
 | `sglang_client.py` | SGLang 视频 API 客户端 |
-| `generate_first_frame.py` | 首帧图提示词与生成（Gemini 或 qwen-plus + Z-Image） |
+| `generate_first_frame.py` | 首帧图提示词与生成（Gemini、qwen-plus 或 MiniMax + Z-Image） |
 | `qwen_vl_api.py` | 从图片提取视觉元素（Qwen3-VL） |
-| `prompt_rewriter_with_image.py` | 视频描述改写（Gemini 或 qwen-plus） |
+| `prompt_rewriter_with_image.py` | 视频描述改写（Gemini、qwen-plus 或 MiniMax） |
 | `launch_sglang_server.sh` | SGLang 服务启动脚本（需设置环境变量 `MOVA_MODEL_PATH` 为模型目录） |
 | `launch_streamlit.sh` | Streamlit 应用启动脚本 |

--- a/workflow/api_utils.py
+++ b/workflow/api_utils.py
@@ -12,17 +12,19 @@ from config import DASHSCOPE_BASE_URL
 def resolve_api_keys(
     api_key: Optional[str] = None,
     qwen_api_key: Optional[str] = None,
-) -> Tuple[str, str]:
+    minimax_api_key: Optional[str] = None,
+) -> Tuple[str, str, str]:
     """
-    统一解析 Gemini 和 DashScope/Qwen API Key。
+    统一解析 Gemini、DashScope/Qwen 和 MiniMax API Key。
     优先级：参数 > 环境变量
 
     Returns:
-        (gemini_key, qwen_key)
+        (gemini_key, qwen_key, minimax_key)
     """
     gemini = (api_key or "").strip() or os.getenv("GEMINI_API_KEY", "")
     qwen = (qwen_api_key or "").strip() or os.getenv("DASHSCOPE_API_KEY", "")
-    return gemini, qwen
+    minimax = (minimax_api_key or "").strip() or os.getenv("MINIMAX_API_KEY", "")
+    return gemini, qwen, minimax
 
 
 def setup_dashscope_url(base_url: Optional[str] = None) -> None:

--- a/workflow/app.py
+++ b/workflow/app.py
@@ -22,6 +22,7 @@ from config import (
     GEMINI_API_URL,
     GEMINI_API_KEY,
     QWEN_VL_API_KEY,
+    MINIMAX_API_KEY,
     POLL_INTERVAL,
     TASK_TIMEOUT,
     OUTPUT_DIR,
@@ -225,19 +226,26 @@ def render_sidebar() -> Dict[str, Any]:
             value=GEMINI_API_URL,
             type="default"
         )
-        
+
         gemini_api_key = st.text_input(
             "Gemini API Key",
             value=GEMINI_API_KEY or "",
             type="password"
         )
-        
+
         qwen_key = st.text_input(
             "Qwen API Key",
             value=QWEN_VL_API_KEY or "",
             type="password"
         )
-    
+
+        minimax_key = st.text_input(
+            "MiniMax API Key",
+            value=MINIMAX_API_KEY or "",
+            type="password",
+            help="MiniMax API key for prompt generation (OpenAI-compatible). Get one at https://platform.minimaxi.com/"
+        )
+
     return {
         'server_key': server_key,
         'video_size': video_size,
@@ -249,7 +257,8 @@ def render_sidebar() -> Dict[str, Any]:
         'num_inference_steps': num_inference_steps,
         'gemini_url': gemini_url,
         'gemini_api_key': gemini_api_key,
-        'qwen_key': qwen_key
+        'qwen_key': qwen_key,
+        'minimax_key': minimax_key
     }
 
 
@@ -480,8 +489,9 @@ def run_full_workflow(user_input: str, uploaded_file, config: Dict[str, Any]):
             # 优先使用 Gemini：有 Gemini key 时始终用 Gemini；仅当无 Gemini 时才用 Qwen/Z-Image
             gemini_key = (config.get('gemini_api_key') or '').strip()
             qwen_key = (config.get('qwen_key') or '').strip()
+            minimax_key = (config.get('minimax_key') or '').strip()
             spinner_msg = "🔄 Generating image prompt and first frame..." + (
-                " (Gemini)" if gemini_key else " (通义 qwen-plus + Z-Image)"
+                " (Gemini)" if gemini_key else (" (MiniMax + Z-Image)" if minimax_key and not qwen_key else " (通义 qwen-plus + Z-Image)")
             )
             with st.spinner(spinner_msg):
                 # Map orientation to aspect ratio for first frame generation
@@ -498,6 +508,8 @@ def run_full_workflow(user_input: str, uploaded_file, config: Dict[str, Any]):
                     cmd.extend(['--api-key', gemini_key, '--api-url', config['gemini_url']])
                 if qwen_key:
                     cmd.extend(['--qwen-api-key', qwen_key])
+                if minimax_key:
+                    cmd.extend(['--minimax-api-key', minimax_key])
                 first_frame_result = subprocess.run(
                     cmd,
                     capture_output=True,
@@ -575,6 +587,8 @@ def run_full_workflow(user_input: str, uploaded_file, config: Dict[str, Any]):
                 rewriter_cmd.extend(['--api-url', config['gemini_url'], '--api-key', config['gemini_api_key']])
             if (config.get('qwen_key') or '').strip():
                 rewriter_cmd.extend(['--qwen-api-key', config['qwen_key']])
+            if (config.get('minimax_key') or '').strip():
+                rewriter_cmd.extend(['--minimax-api-key', config['minimax_key']])
             rewriter_result = subprocess.run(
                 rewriter_cmd,
                 capture_output=True,

--- a/workflow/config.py
+++ b/workflow/config.py
@@ -74,6 +74,25 @@ GEMINI_MODEL = os.environ.get(
 )
 
 # ============================================================================
+# MiniMax API Configuration (OpenAI-compatible alternative for prompt tasks)
+# ============================================================================
+
+MINIMAX_API_KEY = os.environ.get(
+    'MINIMAX_API_KEY',
+    ''
+)
+
+MINIMAX_BASE_URL = os.environ.get(
+    'MINIMAX_BASE_URL',
+    'https://api.minimax.io/v1'
+)
+
+MINIMAX_MODEL = os.environ.get(
+    'MINIMAX_MODEL',
+    'MiniMax-M2.7'
+)
+
+# ============================================================================
 # DashScope API Configuration (Qwen VL / Z-Image / qwen-plus 等)
 # 北京地域默认；可设 DASHSCOPE_BASE_URL 换地域（如新加坡、美国）
 # ============================================================================

--- a/workflow/generate_first_frame.py
+++ b/workflow/generate_first_frame.py
@@ -34,7 +34,12 @@ try:
 except ImportError:
     dashscope = None
 
-from config import DASHSCOPE_MULTIMODAL_GENERATION_URL, GEMINI_API_URL, GEMINI_MODEL
+try:
+    from openai import OpenAI as _OpenAI
+except ImportError:
+    _OpenAI = None
+
+from config import DASHSCOPE_MULTIMODAL_GENERATION_URL, GEMINI_API_URL, GEMINI_MODEL, MINIMAX_BASE_URL, MINIMAX_MODEL
 from api_utils import setup_dashscope_url, resolve_api_keys
 
 
@@ -187,6 +192,51 @@ def generate_image_prompt_qwen(
 
     content = response.output.choices[0].message.content
     image_prompt = (content or "").strip()
+    if not image_prompt:
+        raise ValueError("API返回了空的提示词")
+
+    return image_prompt
+
+
+def generate_image_prompt_minimax(
+    user_input: str,
+    api_key: str,
+    model: str = "MiniMax-M2.7",
+    base_url: str = None,
+) -> str:
+    """
+    使用 MiniMax OpenAI-compatible API 生成首帧图提示词。
+
+    Args:
+        user_input: 用户原始输入
+        api_key: MiniMax API Key
+        model: 模型名称，默认 MiniMax-M2.7
+        base_url: API base URL（可选，默认 https://api.minimax.io/v1）
+
+    Returns:
+        首帧图生成提示词
+    """
+    if _OpenAI is None:
+        raise ImportError("使用 MiniMax 需安装 openai: pip install openai")
+
+    client = _OpenAI(
+        api_key=api_key,
+        base_url=base_url or MINIMAX_BASE_URL,
+    )
+
+    user_prompt = IMAGE_PROMPT_USER.format(user_input=user_input)
+
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": IMAGE_PROMPT_SYSTEM},
+            {"role": "user", "content": user_prompt},
+        ],
+        temperature=0.7,
+    )
+
+    content = response.choices[0].message.content or ""
+    image_prompt = content.strip()
     if not image_prompt:
         raise ValueError("API返回了空的提示词")
 
@@ -394,6 +444,8 @@ def main():
     full_parser.add_argument('--api-url', type=str, default=None, help='Gemini API base URL（使用 Gemini 时必填）')
     full_parser.add_argument('--qwen-api-key', type=str, default=None,
                             help='DashScope/Qwen API key，用于 Z-Image；无 Gemini key 时使用')
+    full_parser.add_argument('--minimax-api-key', type=str, default=None,
+                            help='MiniMax API key，用于提示词生成（无 Gemini/Qwen key 时使用）')
     full_parser.add_argument('--pro-model', type=str, default=None, help='提示词生成模型（默认: gemini-2.5-pro，仅 Gemini）')
     full_parser.add_argument('--aspect-ratio', type=str, choices=['16:9', '9:16'], default='16:9',
                             help='宽高比 (默认: 16:9)')
@@ -404,6 +456,7 @@ def main():
     prompt_parser.add_argument('--api-url', type=str, default=None, help='Gemini API base URL（使用 Gemini 时必填）')
     prompt_parser.add_argument('--api-key', type=str, default=None, help='Gemini API key（与 --qwen-api-key 二选一）')
     prompt_parser.add_argument('--qwen-api-key', type=str, default=None, help='DashScope API key，使用 qwen-plus 生成提示词')
+    prompt_parser.add_argument('--minimax-api-key', type=str, default=None, help='MiniMax API key，用于提示词生成')
     prompt_parser.add_argument('--model', type=str, default=None, help='模型名称（Gemini 默认: gemini-2.5-pro；Qwen 默认: qwen-plus）')
     prompt_parser.add_argument('--output', type=str, default=None, help='输出文件路径（不指定则输出到 stdout）')
 
@@ -430,7 +483,11 @@ def main():
     try:
         if args.command == 'full':
             output_path = args.output or DEFAULT_OUTPUT
-            gemini_key, qwen_key = resolve_api_keys(args.api_key, getattr(args, "qwen_api_key", None))
+            gemini_key, qwen_key, minimax_key = resolve_api_keys(
+                args.api_key,
+                getattr(args, "qwen_api_key", None),
+                getattr(args, "minimax_api_key", None),
+            )
 
             if gemini_key and args.api_url:
                 # 有 Gemini key：先生成提示词，再用 Gemini 或 Z-Image 生图
@@ -448,8 +505,16 @@ def main():
                     api_key=qwen_key,
                     model="qwen-plus",
                 )
+            elif minimax_key:
+                # 使用 MiniMax 生成提示词（仍需要 Gemini/Qwen key 生成图片）
+                print("📝 使用 MiniMax 生成首帧图提示词", file=sys.stderr)
+                image_prompt = generate_image_prompt_minimax(
+                    user_input=args.user_input,
+                    api_key=minimax_key,
+                    model=MINIMAX_MODEL,
+                )
             else:
-                raise ValueError("请提供 --api-key (Gemini) 或 --qwen-api-key (DashScope)")
+                raise ValueError("请提供 --api-key (Gemini)、--qwen-api-key (DashScope) 或 --minimax-api-key (MiniMax)")
 
             aspect_ratio = args.aspect_ratio  # Use explicit parameter or default '16:9'
             image_path = generate_image(
@@ -469,7 +534,11 @@ def main():
             print(f"\n✅ 首帧图已保存: {image_path}")
 
         elif args.command == 'prompt':
-            gemini_key, qwen_key = resolve_api_keys(args.api_key, getattr(args, "qwen_api_key", None))
+            gemini_key, qwen_key, minimax_key = resolve_api_keys(
+                args.api_key,
+                getattr(args, "qwen_api_key", None),
+                getattr(args, "minimax_api_key", None),
+            )
             if gemini_key and args.api_url:
                 image_prompt = generate_image_prompt(
                     user_input=args.user_input,
@@ -483,8 +552,14 @@ def main():
                     api_key=qwen_key,
                     model=args.model or "qwen-plus",
                 )
+            elif minimax_key:
+                image_prompt = generate_image_prompt_minimax(
+                    user_input=args.user_input,
+                    api_key=minimax_key,
+                    model=args.model or MINIMAX_MODEL,
+                )
             else:
-                raise ValueError("请提供 --api-key (Gemini) 或 --qwen-api-key (DashScope)")
+                raise ValueError("请提供 --api-key (Gemini)、--qwen-api-key (DashScope) 或 --minimax-api-key (MiniMax)，或设置环境变量")
             if args.output:
                 Path(args.output).parent.mkdir(parents=True, exist_ok=True)
                 with open(args.output, 'w', encoding='utf-8') as f:

--- a/workflow/prompt_rewriter_with_image.py
+++ b/workflow/prompt_rewriter_with_image.py
@@ -28,7 +28,13 @@ try:
 except ImportError:
     dashscope = None
 
+try:
+    from openai import OpenAI as _OpenAI
+except ImportError:
+    _OpenAI = None
+
 from api_utils import setup_dashscope_url, resolve_api_keys
+from config import MINIMAX_BASE_URL, MINIMAX_MODEL
 
 # ============================================================================
 # System Prompt - 基于首帧图元素生成VIDEO_DESCRIPTION
@@ -255,6 +261,58 @@ def generate_video_description_qwen(
 
     return video_description
 
+
+def generate_video_description_minimax(
+    user_input: str,
+    first_frame_elements: str,
+    api_key: str,
+    model: str = "MiniMax-M2.7",
+    base_url: str = None,
+) -> str:
+    """
+    使用 MiniMax OpenAI-compatible API 生成 VIDEO_DESCRIPTION。
+    文档: https://platform.minimaxi.com/document/chat-completion-v2
+
+    Args:
+        user_input: 用户原始输入
+        first_frame_elements: 首帧图视觉元素描述
+        api_key: MiniMax API Key
+        model: 模型名称，默认 MiniMax-M2.7
+        base_url: API base URL（可选，默认 https://api.minimax.io/v1）
+
+    Returns:
+        VIDEO_DESCRIPTION 文本
+    """
+    if _OpenAI is None:
+        raise ImportError("使用 MiniMax 需安装 openai: pip install openai")
+
+    client = _OpenAI(
+        api_key=api_key,
+        base_url=base_url or MINIMAX_BASE_URL,
+    )
+
+    user_prompt = USER_PROMPT.format(
+        first_frame_elements=first_frame_elements,
+        user_input=user_input
+    )
+
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": SYSTEM_INSTRUCTION},
+            {"role": "user", "content": user_prompt},
+        ],
+        temperature=0.7,
+    )
+
+    content = response.choices[0].message.content or ""
+    video_description = content.strip()
+    if not video_description:
+        raise ValueError("API返回了空的VIDEO_DESCRIPTION")
+
+    return video_description
+
+
 # ============================================================================
 # 命令行接口
 # ============================================================================
@@ -307,7 +365,13 @@ def main():
         '--model',
         type=str,
         default=None,
-        help='模型名称（Gemini 默认: gemini-2.5-pro；Qwen 默认: qwen-plus）'
+        help='模型名称（Gemini 默认: gemini-2.5-pro；Qwen 默认: qwen-plus；MiniMax 默认: MiniMax-M2.7）'
+    )
+    parser.add_argument(
+        '--minimax-api-key',
+        type=str,
+        default=None,
+        help='MiniMax API 密钥（OpenAI-compatible，无 Gemini/Qwen 时使用）'
     )
     parser.add_argument(
         '--output',
@@ -347,7 +411,11 @@ def main():
         print(f"   首帧图元素: {first_frame_elements[:100]}...", file=sys.stderr)
         print("", file=sys.stderr)
 
-        gemini_key, qwen_key = resolve_api_keys(args.api_key, getattr(args, "qwen_api_key", None))
+        gemini_key, qwen_key, minimax_key = resolve_api_keys(
+            args.api_key,
+            getattr(args, "qwen_api_key", None),
+            getattr(args, "minimax_api_key", None),
+        )
 
         if gemini_key and args.api_url:
             video_description = generate_video_description(
@@ -365,8 +433,16 @@ def main():
                 api_key=qwen_key,
                 model=args.model or "qwen-plus",
             )
+        elif minimax_key:
+            print("   使用 MiniMax 生成视频描述", file=sys.stderr)
+            video_description = generate_video_description_minimax(
+                user_input=args.user_input,
+                first_frame_elements=first_frame_elements,
+                api_key=minimax_key,
+                model=args.model or MINIMAX_MODEL,
+            )
         else:
-            raise ValueError("请提供 --api-key (Gemini) 或 --qwen-api-key (DashScope)，或设置环境变量")
+            raise ValueError("请提供 --api-key (Gemini)、--qwen-api-key (DashScope) 或 --minimax-api-key (MiniMax)，或设置环境变量")
         
         # 输出结果
         if args.output:

--- a/workflow/tests/test_minimax_integration.py
+++ b/workflow/tests/test_minimax_integration.py
@@ -1,0 +1,69 @@
+"""Integration tests for MiniMax LLM provider (require MINIMAX_API_KEY)."""
+
+import os
+import sys
+import unittest
+
+# Add workflow directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+MINIMAX_API_KEY = os.environ.get('MINIMAX_API_KEY', '')
+
+
+@unittest.skipUnless(MINIMAX_API_KEY, 'MINIMAX_API_KEY not set')
+class TestMiniMaxVideoDescriptionIntegration(unittest.TestCase):
+    """Integration tests for video description generation with MiniMax API."""
+
+    def test_generate_video_description(self):
+        from prompt_rewriter_with_image import generate_video_description_minimax
+
+        result = generate_video_description_minimax(
+            user_input="A cat sits at a grand piano in a cozy living room and plays a gentle melody",
+            first_frame_elements=(
+                "Visual Style: Warm cinematic realism. "
+                "Camera: Medium shot at eye level. "
+                "Visual Elements: A tabby cat sits on a piano bench facing a black grand piano. "
+                "Warm ambient lighting from a floor lamp."
+            ),
+            api_key=MINIMAX_API_KEY,
+        )
+
+        self.assertIsInstance(result, str)
+        self.assertGreater(len(result), 50)
+
+    def test_generate_video_description_m27_highspeed(self):
+        from prompt_rewriter_with_image import generate_video_description_minimax
+
+        result = generate_video_description_minimax(
+            user_input="A dog runs through a field of sunflowers on a sunny day",
+            first_frame_elements=(
+                "Visual Style: Bright outdoor photography. "
+                "Camera: Wide shot. "
+                "Visual Elements: A golden retriever mid-stride in a sunflower field."
+            ),
+            api_key=MINIMAX_API_KEY,
+            model="MiniMax-M2.7-highspeed",
+        )
+
+        self.assertIsInstance(result, str)
+        self.assertGreater(len(result), 50)
+
+
+@unittest.skipUnless(MINIMAX_API_KEY, 'MINIMAX_API_KEY not set')
+class TestMiniMaxImagePromptIntegration(unittest.TestCase):
+    """Integration tests for image prompt generation with MiniMax API."""
+
+    def test_generate_image_prompt(self):
+        from generate_first_frame import generate_image_prompt_minimax
+
+        result = generate_image_prompt_minimax(
+            user_input="A cozy coffee shop on a rainy evening with warm lighting inside",
+            api_key=MINIMAX_API_KEY,
+        )
+
+        self.assertIsInstance(result, str)
+        self.assertGreater(len(result), 30)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/workflow/tests/test_minimax_provider.py
+++ b/workflow/tests/test_minimax_provider.py
@@ -1,0 +1,413 @@
+"""Unit tests for MiniMax LLM provider integration."""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+# Add workflow directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+
+class TestResolveApiKeys(unittest.TestCase):
+    """Tests for api_utils.resolve_api_keys with MiniMax support."""
+
+    def test_returns_three_tuple(self):
+        from api_utils import resolve_api_keys
+        result = resolve_api_keys()
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 3)
+
+    def test_params_take_priority_over_env(self):
+        from api_utils import resolve_api_keys
+        with patch.dict(os.environ, {
+            'GEMINI_API_KEY': 'env_gemini',
+            'DASHSCOPE_API_KEY': 'env_qwen',
+            'MINIMAX_API_KEY': 'env_minimax',
+        }):
+            gemini, qwen, minimax = resolve_api_keys(
+                api_key='param_gemini',
+                qwen_api_key='param_qwen',
+                minimax_api_key='param_minimax',
+            )
+            self.assertEqual(gemini, 'param_gemini')
+            self.assertEqual(qwen, 'param_qwen')
+            self.assertEqual(minimax, 'param_minimax')
+
+    def test_env_fallback(self):
+        from api_utils import resolve_api_keys
+        with patch.dict(os.environ, {
+            'GEMINI_API_KEY': 'env_gemini',
+            'DASHSCOPE_API_KEY': 'env_qwen',
+            'MINIMAX_API_KEY': 'env_minimax',
+        }):
+            gemini, qwen, minimax = resolve_api_keys()
+            self.assertEqual(gemini, 'env_gemini')
+            self.assertEqual(qwen, 'env_qwen')
+            self.assertEqual(minimax, 'env_minimax')
+
+    def test_empty_when_no_keys(self):
+        from api_utils import resolve_api_keys
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove any existing env vars
+            for key in ['GEMINI_API_KEY', 'DASHSCOPE_API_KEY', 'MINIMAX_API_KEY']:
+                os.environ.pop(key, None)
+            gemini, qwen, minimax = resolve_api_keys()
+            self.assertEqual(gemini, '')
+            self.assertEqual(qwen, '')
+            self.assertEqual(minimax, '')
+
+    def test_strips_whitespace(self):
+        from api_utils import resolve_api_keys
+        gemini, qwen, minimax = resolve_api_keys(
+            api_key='  gemini  ',
+            qwen_api_key='  qwen  ',
+            minimax_api_key='  minimax  ',
+        )
+        self.assertEqual(gemini, 'gemini')
+        self.assertEqual(qwen, 'qwen')
+        self.assertEqual(minimax, 'minimax')
+
+    def test_none_params_fall_through_to_env(self):
+        from api_utils import resolve_api_keys
+        with patch.dict(os.environ, {'MINIMAX_API_KEY': 'from_env'}):
+            _, _, minimax = resolve_api_keys(minimax_api_key=None)
+            self.assertEqual(minimax, 'from_env')
+
+
+class TestMiniMaxConfig(unittest.TestCase):
+    """Tests for MiniMax configuration in config.py."""
+
+    def test_minimax_config_defaults(self):
+        from config import MINIMAX_API_KEY, MINIMAX_BASE_URL, MINIMAX_MODEL
+        self.assertIsInstance(MINIMAX_API_KEY, str)
+        self.assertEqual(MINIMAX_BASE_URL, 'https://api.minimax.io/v1')
+        self.assertEqual(MINIMAX_MODEL, 'MiniMax-M2.7')
+
+    def test_minimax_config_from_env(self):
+        with patch.dict(os.environ, {
+            'MINIMAX_API_KEY': 'test_key_123',
+            'MINIMAX_BASE_URL': 'https://custom.api/v1',
+            'MINIMAX_MODEL': 'MiniMax-M2.5',
+        }):
+            # Re-import to pick up env vars
+            import importlib
+            import config
+            importlib.reload(config)
+            self.assertEqual(config.MINIMAX_API_KEY, 'test_key_123')
+            self.assertEqual(config.MINIMAX_BASE_URL, 'https://custom.api/v1')
+            self.assertEqual(config.MINIMAX_MODEL, 'MiniMax-M2.5')
+            # Reload with clean env
+            for key in ['MINIMAX_API_KEY', 'MINIMAX_BASE_URL', 'MINIMAX_MODEL']:
+                os.environ.pop(key, None)
+            importlib.reload(config)
+
+
+class TestVideoDescriptionMinimax(unittest.TestCase):
+    """Tests for generate_video_description_minimax in prompt_rewriter_with_image.py."""
+
+    @patch('prompt_rewriter_with_image._OpenAI')
+    def test_calls_openai_compatible_api(self, mock_openai_cls):
+        from prompt_rewriter_with_image import generate_video_description_minimax
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "A detailed video description..."
+        mock_client.chat.completions.create.return_value = mock_response
+
+        result = generate_video_description_minimax(
+            user_input="A cat plays piano",
+            first_frame_elements="A tabby cat sits at a piano",
+            api_key="test_key",
+            model="MiniMax-M2.7",
+        )
+
+        mock_openai_cls.assert_called_once_with(
+            api_key="test_key",
+            base_url="https://api.minimax.io/v1",
+        )
+        call_args = mock_client.chat.completions.create.call_args
+        self.assertEqual(call_args.kwargs['model'], 'MiniMax-M2.7')
+        self.assertEqual(len(call_args.kwargs['messages']), 2)
+        self.assertEqual(call_args.kwargs['messages'][0]['role'], 'system')
+        self.assertEqual(call_args.kwargs['messages'][1]['role'], 'user')
+        self.assertIn('cat plays piano', call_args.kwargs['messages'][1]['content'])
+        self.assertLessEqual(call_args.kwargs['temperature'], 1.0)
+        self.assertGreater(call_args.kwargs['temperature'], 0.0)
+        self.assertEqual(result, "A detailed video description...")
+
+    @patch('prompt_rewriter_with_image._OpenAI')
+    def test_custom_base_url(self, mock_openai_cls):
+        from prompt_rewriter_with_image import generate_video_description_minimax
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "description"
+        mock_client.chat.completions.create.return_value = mock_response
+
+        generate_video_description_minimax(
+            user_input="test",
+            first_frame_elements="test",
+            api_key="key",
+            base_url="https://custom.api/v1",
+        )
+
+        mock_openai_cls.assert_called_once_with(
+            api_key="key",
+            base_url="https://custom.api/v1",
+        )
+
+    @patch('prompt_rewriter_with_image._OpenAI')
+    def test_raises_on_empty_response(self, mock_openai_cls):
+        from prompt_rewriter_with_image import generate_video_description_minimax
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = ""
+        mock_client.chat.completions.create.return_value = mock_response
+
+        with self.assertRaises(ValueError):
+            generate_video_description_minimax(
+                user_input="test",
+                first_frame_elements="test",
+                api_key="key",
+            )
+
+    @patch('prompt_rewriter_with_image._OpenAI')
+    def test_raises_on_none_response(self, mock_openai_cls):
+        from prompt_rewriter_with_image import generate_video_description_minimax
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = None
+        mock_client.chat.completions.create.return_value = mock_response
+
+        with self.assertRaises(ValueError):
+            generate_video_description_minimax(
+                user_input="test",
+                first_frame_elements="test",
+                api_key="key",
+            )
+
+    @patch('prompt_rewriter_with_image._OpenAI')
+    def test_strips_whitespace_from_result(self, mock_openai_cls):
+        from prompt_rewriter_with_image import generate_video_description_minimax
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "  result text  \n"
+        mock_client.chat.completions.create.return_value = mock_response
+
+        result = generate_video_description_minimax(
+            user_input="test",
+            first_frame_elements="test",
+            api_key="key",
+        )
+        self.assertEqual(result, "result text")
+
+    def test_raises_without_openai(self):
+        import prompt_rewriter_with_image as module
+        original = module._OpenAI
+        module._OpenAI = None
+        try:
+            with self.assertRaises(ImportError):
+                module.generate_video_description_minimax(
+                    user_input="test",
+                    first_frame_elements="test",
+                    api_key="key",
+                )
+        finally:
+            module._OpenAI = original
+
+
+class TestImagePromptMinimax(unittest.TestCase):
+    """Tests for generate_image_prompt_minimax in generate_first_frame.py."""
+
+    @patch('generate_first_frame._OpenAI')
+    def test_calls_openai_compatible_api(self, mock_openai_cls):
+        from generate_first_frame import generate_image_prompt_minimax
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "A medium shot of a cat at a grand piano..."
+        mock_client.chat.completions.create.return_value = mock_response
+
+        result = generate_image_prompt_minimax(
+            user_input="A cat plays piano",
+            api_key="test_key",
+            model="MiniMax-M2.7",
+        )
+
+        mock_openai_cls.assert_called_once_with(
+            api_key="test_key",
+            base_url="https://api.minimax.io/v1",
+        )
+        call_args = mock_client.chat.completions.create.call_args
+        self.assertEqual(call_args.kwargs['model'], 'MiniMax-M2.7')
+        self.assertEqual(len(call_args.kwargs['messages']), 2)
+        self.assertIn('cat plays piano', call_args.kwargs['messages'][1]['content'])
+        self.assertEqual(result, "A medium shot of a cat at a grand piano...")
+
+    @patch('generate_first_frame._OpenAI')
+    def test_raises_on_empty_response(self, mock_openai_cls):
+        from generate_first_frame import generate_image_prompt_minimax
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = ""
+        mock_client.chat.completions.create.return_value = mock_response
+
+        with self.assertRaises(ValueError):
+            generate_image_prompt_minimax(
+                user_input="test",
+                api_key="key",
+            )
+
+    @patch('generate_first_frame._OpenAI')
+    def test_custom_base_url(self, mock_openai_cls):
+        from generate_first_frame import generate_image_prompt_minimax
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "prompt"
+        mock_client.chat.completions.create.return_value = mock_response
+
+        generate_image_prompt_minimax(
+            user_input="test",
+            api_key="key",
+            base_url="https://custom.api/v1",
+        )
+
+        mock_openai_cls.assert_called_once_with(
+            api_key="key",
+            base_url="https://custom.api/v1",
+        )
+
+    def test_raises_without_openai(self):
+        import generate_first_frame as module
+        original = module._OpenAI
+        module._OpenAI = None
+        try:
+            with self.assertRaises(ImportError):
+                module.generate_image_prompt_minimax(
+                    user_input="test",
+                    api_key="key",
+                )
+        finally:
+            module._OpenAI = original
+
+    @patch('generate_first_frame._OpenAI')
+    def test_temperature_within_bounds(self, mock_openai_cls):
+        from generate_first_frame import generate_image_prompt_minimax
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "prompt text"
+        mock_client.chat.completions.create.return_value = mock_response
+
+        generate_image_prompt_minimax(user_input="test", api_key="key")
+
+        call_args = mock_client.chat.completions.create.call_args
+        temp = call_args.kwargs['temperature']
+        self.assertGreater(temp, 0.0)
+        self.assertLessEqual(temp, 1.0)
+
+
+class TestProviderFallbackChain(unittest.TestCase):
+    """Tests for the Gemini → Qwen → MiniMax fallback chain."""
+
+    @patch('prompt_rewriter_with_image._OpenAI')
+    @patch('prompt_rewriter_with_image.genai', None)
+    @patch('prompt_rewriter_with_image.dashscope', None)
+    def test_minimax_fallback_in_prompt_rewriter(self, mock_openai_cls):
+        """When only MiniMax key is set, prompt rewriter should use MiniMax."""
+        from prompt_rewriter_with_image import (
+            generate_video_description_minimax,
+        )
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "MiniMax generated description"
+        mock_client.chat.completions.create.return_value = mock_response
+
+        result = generate_video_description_minimax(
+            user_input="test input",
+            first_frame_elements="test elements",
+            api_key="minimax_key",
+        )
+        self.assertEqual(result, "MiniMax generated description")
+        mock_openai_cls.assert_called_once()
+
+
+class TestSystemPromptContent(unittest.TestCase):
+    """Tests that system prompts are properly passed to MiniMax."""
+
+    @patch('prompt_rewriter_with_image._OpenAI')
+    def test_system_prompt_is_video_description_expert(self, mock_openai_cls):
+        from prompt_rewriter_with_image import (
+            generate_video_description_minimax,
+            SYSTEM_INSTRUCTION,
+        )
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "description"
+        mock_client.chat.completions.create.return_value = mock_response
+
+        generate_video_description_minimax(
+            user_input="test",
+            first_frame_elements="test",
+            api_key="key",
+        )
+
+        call_args = mock_client.chat.completions.create.call_args
+        system_msg = call_args.kwargs['messages'][0]
+        self.assertEqual(system_msg['role'], 'system')
+        self.assertEqual(system_msg['content'], SYSTEM_INSTRUCTION)
+
+    @patch('generate_first_frame._OpenAI')
+    def test_image_prompt_system_is_first_frame_expert(self, mock_openai_cls):
+        from generate_first_frame import (
+            generate_image_prompt_minimax,
+            IMAGE_PROMPT_SYSTEM,
+        )
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "prompt"
+        mock_client.chat.completions.create.return_value = mock_response
+
+        generate_image_prompt_minimax(user_input="test", api_key="key")
+
+        call_args = mock_client.chat.completions.create.call_args
+        system_msg = call_args.kwargs['messages'][0]
+        self.assertEqual(system_msg['role'], 'system')
+        self.assertEqual(system_msg['content'], IMAGE_PROMPT_SYSTEM)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds [MiniMax](https://platform.minimaxi.com/) (MiniMax-M2.7, 204K context) as a third LLM provider option alongside Gemini and DashScope/Qwen for the AI-assisted video generation workflow. MiniMax uses its OpenAI-compatible API (`https://api.minimax.io/v1`) for prompt rewriting and image prompt generation tasks.

### Changes

- **`config.py`**: Add `MINIMAX_API_KEY`, `MINIMAX_BASE_URL`, `MINIMAX_MODEL` env-based settings
- **`api_utils.py`**: Extend `resolve_api_keys()` to return 3-tuple including MiniMax key
- **`prompt_rewriter_with_image.py`**: Add `generate_video_description_minimax()` using OpenAI SDK
- **`generate_first_frame.py`**: Add `generate_image_prompt_minimax()` using OpenAI SDK
- **`app.py`**: Add MiniMax API Key input in Streamlit sidebar, pass key through full workflow pipeline
- **`workflow/README.md`**: Document MiniMax as a provider option (English + Chinese sections)
- **`tests/`**: 22 unit tests + 3 integration tests (all passing)

### Provider Fallback Chain

```
Gemini API Key → use Gemini
  ↓ (not set)
DashScope API Key → use qwen-plus
  ↓ (not set)
MiniMax API Key → use MiniMax-M2.7
```

### Usage

Set the `MINIMAX_API_KEY` environment variable, or enter it in the Streamlit sidebar under API Keys. The workflow will use MiniMax for prompt rewriting and image prompt generation when Gemini and DashScope keys are not available.

```bash
export MINIMAX_API_KEY="your-api-key"
```

> **Note**: MiniMax is used for text generation tasks only (prompt rewriting, image prompt generation). Image generation still requires Gemini or DashScope/Z-Image APIs. Visual element extraction still uses Qwen3-VL.

## Test Plan

- [x] 22 unit tests covering config, API key resolution, OpenAI-compat calls, error handling, fallback chain, system prompts
- [x] 3 integration tests with live MiniMax API (M2.7 + M2.7-highspeed)
- [x] All tests pass

9 files changed, 693 additions(+), 23 deletions(-)