### PR TITLE
fix(npu): synchronize stream after backward for dp replicate training

### DIFF
--- a/mova/engine/trainer/accelerate/accelerate_trainer.py
+++ b/mova/engine/trainer/accelerate/accelerate_trainer.py
@@ -9,6 +9,7 @@ Supports:
 
 import os, re
 import torch
+import torch_npu
 from tqdm import tqdm
 
 try:
@@ -411,6 +412,8 @@ class AccelerateTrainer:
                 loss = loss_dict["loss"]
                 
                 self.accelerator.backward(loss)
+                # Synchronize NPU stream to avoid async ordering issues with DP replicate training.
+                torch_npu.npu.current_stream().synchronize()
                 
                 if self.gradient_clip_norm > 0:
                     if self.accelerator.sync_gradients:


### PR DESCRIPTION
## Summary

Fixes #59.

This PR fixes loss=nan in NPU training when dp_replicate_size > 1 by synchronizing the current NPU stream immediately after backward.

## Details

- Adds torch_npu import in mova/engine/trainer/accelerate/accelerate_trainer.py
- Calls torch_npu.npu.current_stream().synchronize() right after self.accelerator.backward(loss)
- Keeps the change scoped to NPU stream ordering after backward
- Does not modify other training logic

## Test

- python3 -m compileall mova/engine/trainer/accelerate/accelerate_trainer.py
- git diff --check