### PR TITLE
fix: avoid duplicate tqdm progress refresh during training

### DIFF
--- a/mova/engine/trainer/accelerate/accelerate_trainer.py
+++ b/mova/engine/trainer/accelerate/accelerate_trainer.py
@@ -451,7 +451,8 @@ class AccelerateTrainer:
                     "v_loss": f"{avg_video_loss:.4f}",
                     "a_loss": f"{avg_audio_loss:.4f}",
                     "lr": f"{lr:.2e}",
-                })
+                }, refresh=False)
+                pbar.update(self.log_interval)
                 
                 accumulated_loss = 0.0
                 accumulated_video_loss = 0.0
@@ -460,8 +461,6 @@ class AccelerateTrainer:
             
             if self.global_step % self.save_interval == 0:
                 self._save_checkpoint()
-            
-            pbar.update(1)
         
         self._save_checkpoint(final=True)
         pbar.close()


### PR DESCRIPTION
## Summary

Fix duplicate tqdm progress records printed for the same MOVA training step.

## Changes

- Set `refresh=False` on `pbar.set_postfix(...)`
- Move tqdm progress update into the `log_interval` block
- Remove the unconditional `pbar.update(1)` at the end of the loop
- Keep the change scoped to tqdm display behavior only

## Validation

- `python3 -m compileall mova/engine/trainer/accelerate/accelerate_trainer.py` passed
- Training validation: each step prints one tqdm line
- Log validation script: duplicate step count = 0

## Risk Assessment

Low risk. This only changes tqdm display refresh behavior and does not modify loss computation, backward, optimizer step, scheduler step, checkpointing, or model logic.



Closes #63
