### PR TITLE
feat(workflow): upgrade default MiniMax model to M3

### DIFF
--- a/workflow/README.md
+++ b/workflow/README.md
@@ -43,7 +43,7 @@ Edit `config.py` to set:
 - **API Keys** (optional, for Full Workflow):
   - `GEMINI_API_KEY` + `GEMINI_API_URL`: Gemini API (recommended; fill base URL when using proxy)
   - `DASHSCOPE_API_KEY` + `DASHSCOPE_BASE_URL`: Qwen/DashScope API (base URL for region, e.g. Singapore/US)
-  - `MINIMAX_API_KEY`: [MiniMax](https://platform.minimaxi.com/) API for prompt generation (OpenAI-compatible; uses MiniMax-M2.7 by default)
+  - `MINIMAX_API_KEY`: [MiniMax](https://platform.minimaxi.com/) API for prompt generation (OpenAI-compatible; uses MiniMax-M3 by default)
 
 > **Note (API Key Fallback):** If you do **not** provide a Gemini API key, the workflow will automatically use the Qwen (DashScope) API key to call qwen-plus and Z-Image for prompt generation and first frame generation. Alternatively, you can use a **MiniMax API key** (`MINIMAX_API_KEY`) for prompt rewriting and image prompt generation via MiniMax's OpenAI-compatible API. **We still recommend using a Gemini API key** for best quality.
 
@@ -115,7 +115,7 @@ export MOVA_MODEL_PATH="/path/to/your/MOVA-360p-hf"   # 或 MOVA-720p-hf
 - **API 密钥**（可选，完整工作流需要）：
   - `GEMINI_API_KEY` + `GEMINI_API_URL`：Gemini API（推荐；使用代理时需填写 base URL）
   - `DASHSCOPE_API_KEY` + `DASHSCOPE_BASE_URL`：通义千问 / DashScope API（base URL 可选，用于指定地域如新加坡/美国）
-  - `MINIMAX_API_KEY`：[MiniMax](https://platform.minimaxi.com/) API，用于提示词生成（OpenAI 兼容接口；默认使用 MiniMax-M2.7）
+  - `MINIMAX_API_KEY`：[MiniMax](https://platform.minimaxi.com/) API，用于提示词生成（OpenAI 兼容接口；默认使用 MiniMax-M3）
 
 > **说明（API 密钥回退）：** 若不提供 Gemini API 密钥，工作流会自动使用 Qwen（DashScope）API 密钥调用 qwen-plus 和 Z-Image 完成提示词生成和首帧图生成。也可使用 **MiniMax API 密钥**（`MINIMAX_API_KEY`）通过 MiniMax 的 OpenAI 兼容 API 完成提示词改写和首帧图提示词生成。**我们仍推荐使用 Gemini API 密钥**以获得更好效果。
 

--- a/workflow/config.py
+++ b/workflow/config.py
@@ -89,7 +89,7 @@ MINIMAX_BASE_URL = os.environ.get(
 
 MINIMAX_MODEL = os.environ.get(
     'MINIMAX_MODEL',
-    'MiniMax-M2.7'
+    'MiniMax-M3'
 )
 
 # ============================================================================

--- a/workflow/generate_first_frame.py
+++ b/workflow/generate_first_frame.py
@@ -201,7 +201,7 @@ def generate_image_prompt_qwen(
 def generate_image_prompt_minimax(
     user_input: str,
     api_key: str,
-    model: str = "MiniMax-M2.7",
+    model: str = "MiniMax-M3",
     base_url: str = None,
 ) -> str:
     """
@@ -210,7 +210,7 @@ def generate_image_prompt_minimax(
     Args:
         user_input: 用户原始输入
         api_key: MiniMax API Key
-        model: 模型名称，默认 MiniMax-M2.7
+        model: 模型名称，默认 MiniMax-M3
         base_url: API base URL（可选，默认 https://api.minimax.io/v1）
 
     Returns:

--- a/workflow/prompt_rewriter_with_image.py
+++ b/workflow/prompt_rewriter_with_image.py
@@ -266,7 +266,7 @@ def generate_video_description_minimax(
     user_input: str,
     first_frame_elements: str,
     api_key: str,
-    model: str = "MiniMax-M2.7",
+    model: str = "MiniMax-M3",
     base_url: str = None,
 ) -> str:
     """
@@ -277,7 +277,7 @@ def generate_video_description_minimax(
         user_input: 用户原始输入
         first_frame_elements: 首帧图视觉元素描述
         api_key: MiniMax API Key
-        model: 模型名称，默认 MiniMax-M2.7
+        model: 模型名称，默认 MiniMax-M3
         base_url: API base URL（可选，默认 https://api.minimax.io/v1）
 
     Returns:
@@ -365,7 +365,7 @@ def main():
         '--model',
         type=str,
         default=None,
-        help='模型名称（Gemini 默认: gemini-2.5-pro；Qwen 默认: qwen-plus；MiniMax 默认: MiniMax-M2.7）'
+        help='模型名称（Gemini 默认: gemini-2.5-pro；Qwen 默认: qwen-plus；MiniMax 默认: MiniMax-M3）'
     )
     parser.add_argument(
         '--minimax-api-key',

--- a/workflow/tests/test_minimax_provider.py
+++ b/workflow/tests/test_minimax_provider.py
@@ -82,13 +82,13 @@ class TestMiniMaxConfig(unittest.TestCase):
         from config import MINIMAX_API_KEY, MINIMAX_BASE_URL, MINIMAX_MODEL
         self.assertIsInstance(MINIMAX_API_KEY, str)
         self.assertEqual(MINIMAX_BASE_URL, 'https://api.minimax.io/v1')
-        self.assertEqual(MINIMAX_MODEL, 'MiniMax-M2.7')
+        self.assertEqual(MINIMAX_MODEL, 'MiniMax-M3')
 
     def test_minimax_config_from_env(self):
         with patch.dict(os.environ, {
             'MINIMAX_API_KEY': 'test_key_123',
             'MINIMAX_BASE_URL': 'https://custom.api/v1',
-            'MINIMAX_MODEL': 'MiniMax-M2.5',
+            'MINIMAX_MODEL': 'MiniMax-M2.7',
         }):
             # Re-import to pick up env vars
             import importlib
@@ -96,7 +96,7 @@ class TestMiniMaxConfig(unittest.TestCase):
             importlib.reload(config)
             self.assertEqual(config.MINIMAX_API_KEY, 'test_key_123')
             self.assertEqual(config.MINIMAX_BASE_URL, 'https://custom.api/v1')
-            self.assertEqual(config.MINIMAX_MODEL, 'MiniMax-M2.5')
+            self.assertEqual(config.MINIMAX_MODEL, 'MiniMax-M2.7')
             # Reload with clean env
             for key in ['MINIMAX_API_KEY', 'MINIMAX_BASE_URL', 'MINIMAX_MODEL']:
                 os.environ.pop(key, None)


### PR DESCRIPTION
## Summary

Upgrade the default MiniMax LLM (`MINIMAX_MODEL`) from `MiniMax-M2.7` to `MiniMax-M3` for the workflow's prompt rewriting and first-frame prompt generation paths. M3 is MiniMax's current flagship and gives better instruction-following on the long, structured prompts this workflow produces.

`MiniMax-M2.7` (and `MiniMax-M2.7-highspeed`) remain fully usable via the `MINIMAX_MODEL` env var or the `--model` CLI flag — the integration test that exercises `M2.7-highspeed` is unchanged.

## Changes

- `workflow/config.py` — default `MINIMAX_MODEL` → `MiniMax-M3`
- `workflow/prompt_rewriter_with_image.py` — default `model` arg of `generate_video_description_minimax`, docstring, and `--model` CLI help text
- `workflow/generate_first_frame.py` — default `model` arg of `generate_image_prompt_minimax` and docstring
- `workflow/README.md` (EN + 中文) — note that the default is `MiniMax-M3`
- `workflow/tests/test_minimax_provider.py` — `test_minimax_config_defaults` now asserts `M3`; the env-override test uses `M2.7` instead of the retired `M2.5`

API base URL (`https://api.minimax.io/v1`), env vars, and TTS/other providers are untouched.

## Test plan

- [x] `python3 -m unittest tests.test_minimax_provider -v` — 22/22 passing
- [ ] (Optional) Run integration tests with a real `MINIMAX_API_KEY` to exercise M3 end-to-end via `generate_video_description_minimax` / `generate_image_prompt_minimax`