### PR TITLE
Fix broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,4 +353,4 @@ We would like to thank the contributors to [Wan](https://github.com/Wan-Video/Wa
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=OpenMOSS/MOVA&type=date&legend=top-left)](https://www.star-history.com/#OpenMOSS/MOVA&type=date&legend=top-left)
+[![Star History Chart](https://api.star-history.com/chart?repos=OpenMOSS%2FMOVA&type=date&legend=top-left&sealed_token=Fi6zs0IAK2C1q00XfDRlsR6jRwxF5O1fYBIeWcCGZ2bDqbHZpBrJlNs3shnvYDo_q92trz5pFAwFKA-bBwakeFUxAABDbq_M-wcJWTBguotr8hw7A1hVDQ)](https://www.star-history.com/?type=date&legend=top-left&repos=OpenMOSS%2FMOVA)


### PR DESCRIPTION
## Summary

Update the README to use Star History's authenticated live chart endpoint after GitHub restricted access to stargazer history.

## Preview

<img width="960" alt="OpenMOSS/MOVA live Star History chart" src="https://api.star-history.com/chart?repos=OpenMOSS%2FMOVA&type=date&legend=top-left&sealed_token=Fi6zs0IAK2C1q00XfDRlsR6jRwxF5O1fYBIeWcCGZ2bDqbHZpBrJlNs3shnvYDo_q92trz5pFAwFKA-bBwakeFUxAABDbq_M-wcJWTBguotr8hw7A1hVDQ">

## Validation

- Confirmed the token can read `OpenMOSS/MOVA` stargazer history.
- Confirmed the live chart endpoint returns HTTP 200 with a valid SVG.
- The PR changes only one line in `README.md`.