### PR TITLE
Automate Star History updates

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,22 @@
+name: Update Star History
+
+on:
+  schedule:
+    - cron: "0 1 * * *" # Daily at 09:00 Asia/Singapore
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: star-history
+  cancel-in-progress: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: narayann7/star-history-action@a68d8f9d67ca20d55b682a264e69152dcf326e9c # v1.0.5
+        with:
+          repos: OpenMOSS/MOVA

--- a/README.md
+++ b/README.md
@@ -353,4 +353,5 @@ We would like to thank the contributors to [Wan](https://github.com/Wan-Video/Wa
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/chart?repos=OpenMOSS%2FMOVA&type=date&legend=top-left&sealed_token=Fi6zs0IAK2C1q00XfDRlsR6jRwxF5O1fYBIeWcCGZ2bDqbHZpBrJlNs3shnvYDo_q92trz5pFAwFKA-bBwakeFUxAABDbq_M-wcJWTBguotr8hw7A1hVDQ)](https://www.star-history.com/?repos=OpenMOSS%2FMOVA&type=date&legend=top-left)
+<!-- star-history:start -->
+<!-- star-history:end -->


### PR DESCRIPTION
## What changed

- Replace the hosted Star History image URL in `README.md` with managed `star-history` markers.
- Add a daily GitHub Actions workflow that renders light/dark Star History assets into the repository.
- Keep a manual `workflow_dispatch` trigger for the first run and ad-hoc refreshes.
- Pin `narayann7/star-history-action` to the v1.0.5 commit.

## Why

The current README chart depends on a hosted `api.star-history.com` URL and an encrypted token. Following GitHub's stargazers API restriction, that hosted chart can fail to render. Generating and committing the chart inside this repository avoids the brittle external image request and does not expose a personal access token.

## Impact

After merge, the workflow runs daily at 09:00 Asia/Singapore. The first scheduled or manually dispatched run will add the generated SVG/PNG assets and populate the README markers. Later runs commit only when the rendered chart changes.

## Validation

- Compared `main...agent/automate-star-history`: one commit, two intended files, no unrelated changes.
- Inspected the generated workflow and README marker placement.
- The workflow itself cannot be exercised until it exists on the default branch.

Repository Actions must permit `GITHUB_TOKEN` write access; protected-branch policy may also need to allow the Actions bot to commit generated assets.