### PR TITLE
Fix ignored seed and sigma shift during sampling

### DIFF
--- a/mova/diffusion/pipelines/pipeline_mova.py
+++ b/mova/diffusion/pipelines/pipeline_mova.py
@@ -348,17 +348,17 @@ class MOVA(DiffusionPipeline):
         cfg_merge = False
         audio_num_samples = int(self.audio_sample_rate * num_frames / video_fps)
 
-        # self.scheduler.set_timesteps(num_inference_steps, denoising_strength=denoising_strength, shift=sigma_shift)
-        # self.scheduler.set_pair_postprocess_by_name(
-        #     "dual_sigma_shift",
-        #     visual_shift=visual_shift,
-        #     audio_shift=audio_shift,
-        # )
-        
         device = self._execution_device
+        # Generate on CPU first so seeded noise is reproducible across execution devices.
+        generator = None if seed is None else torch.Generator(device="cpu").manual_seed(int(seed))
 
         # 4. Prepare timesteps
-        self.scheduler.set_timesteps(num_inference_steps, device=device)
+        self.scheduler.set_timesteps(
+            num_inference_steps,
+            denoising_strength=denoising_strength,
+            shift=sigma_shift,
+            device=device,
+        )
         scheduler_support_audio = hasattr(self.scheduler, "get_pairs")
         if scheduler_support_audio:
             audio_scheduler = self.scheduler
@@ -379,7 +379,7 @@ class MOVA(DiffusionPipeline):
             num_frames,
             torch.float32,
             device,
-            generator=None,
+            generator=generator,
             latents=None,
             last_image=None,
         )
@@ -390,7 +390,7 @@ class MOVA(DiffusionPipeline):
             audio_num_samples,
             torch.float32,
             device,
-            generator=None,
+            generator=generator,
             latents=None,
         )
 


### PR DESCRIPTION
## Summary

The public MOVA inference API accepts both `seed` and `sigma_shift`, and the official inference scripts expose them, but neither value currently reaches sampling:

- `prepare_latents` and `prepare_audio_latents` are called with `generator=None`, so `seed` does not control the pipeline RNG.
- `scheduler.set_timesteps` is called without `shift=sigma_shift`, so non-default sigma shifts are ignored.

This change creates one CPU generator from `seed` and passes it through the video and audio noise initializers, then forwards `sigma_shift` to the scheduler. Reusing one generator keeps the complete joint video-audio sample deterministic, while `seed=None` preserves global-RNG behavior.

The default output schedule is unchanged for the released checkpoints because their scheduler configuration and the public argument both default to shift 5.

## Validation

- Mocked the full pipeline setup through latent initialization and verified that the same seed reproduces both video and audio noise after perturbing the global RNG.
- Verified that changing the seed changes both modalities.
- Verified that `sigma_shift=4.25` is forwarded to `set_timesteps` together with the requested step count and execution device.
- Ran Python 3.12 syntax compilation on Windows and in a clean Linux container.
- Ran `git diff --check`.