### PR TITLE
Fix Star History with a static assets branch

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -22,6 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: star-history-assets
       - uses: narayann7/star-history-action@a68d8f9d67ca20d55b682a264e69152dcf326e9c # v1.0.5
         with:
           repos: OpenMOSS/MOVA
+          update-readme: false

--- a/README.md
+++ b/README.md
@@ -354,4 +354,12 @@ We would like to thank the contributors to [Wan](https://github.com/Wan-Video/Wa
 ## Star History
 
 <!-- star-history:start -->
+<p align="center">
+  <a href="https://github.com/OpenMOSS/MOVA/stargazers">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/OpenMOSS/MOVA/star-history-assets/assets/star-history/star-history-dark.svg">
+      <img alt="MOVA star history" src="https://raw.githubusercontent.com/OpenMOSS/MOVA/star-history-assets/assets/star-history/star-history-light.svg">
+    </picture>
+  </a>
+</p>
 <!-- star-history:end -->


### PR DESCRIPTION
## What changed

- publish generated Star History SVG/PNG files to `star-history-assets`
- embed the light/dark SVGs from that branch in the main README
- keep the existing daily schedule and manual dispatch
- use only the repository-scoped `GITHUB_TOKEN`

## Why

The generator successfully fetched stargazers and rendered the chart, but its commit to protected `main` was rejected. Writing generated artifacts to a dedicated branch avoids bypassing branch protection and avoids recurring pull requests.

The workflow remains pinned to `narayann7/star-history-action` v1.0.5 by commit SHA.